### PR TITLE
Tint iOS status bar to match hero, tracking theme toggle

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,22 +2,32 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
+<!-- iOS status-bar / browser-chrome tint. These match the *composited* top of
+     the page (porcelain + hero photo overlay), not flat porcelain, so the bar
+     blends into the hero instead of showing a pale band above the content.
+     Driven by JS below so it tracks the manual theme toggle, not just the OS. -->
+<meta name="theme-color" content="#f6ebdc" />
 <script>
-  // Set the theme before first paint to avoid a flash of the wrong theme.
+  // Set the theme before first paint to avoid a flash of the wrong theme,
+  // and tint the status bar to match the chosen theme straight away.
   (function () {
+    var dark = false;
     try {
       var t = localStorage.getItem("theme");
       if (t === "dark" || (!t && matchMedia("(prefers-color-scheme: dark)").matches)) {
         document.documentElement.classList.add("dark");
+        dark = true;
       }
     } catch (e) {}
+    if (dark) {
+      var m = document.querySelector('meta[name="theme-color"]');
+      if (m) m.content = "#4f524b";
+    }
   })();
 </script>
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 <title>{{ page.title }} — {{ site.title }}</title>
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<meta name="theme-color" content="#f8f7f1" media="(prefers-color-scheme: light)" />
-<meta name="theme-color" content="#15201e" media="(prefers-color-scheme: dark)" />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <link href="/atom.xml" type="application/atom+xml" rel="alternate" title="tgvashworth atom feed" />
 
@@ -84,6 +94,9 @@
       var label = document.getElementById("theme-label");
       if (icon) icon.textContent = dark ? "☀" : "☽";
       if (label) label.textContent = dark ? "Light" : "Dark";
+      // Keep the status-bar tint matched to the active theme.
+      var meta = document.querySelector('meta[name="theme-color"]');
+      if (meta) meta.content = dark ? "#4f524b" : "#f6ebdc";
     }
     update();
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,11 +2,10 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<!-- iOS status-bar / browser-chrome tint. These match the *composited* top of
-     the page (porcelain + hero photo overlay), not flat porcelain, so the bar
-     blends into the hero instead of showing a pale band above the content.
-     Driven by JS below so it tracks the manual theme toggle, not just the OS. -->
-<meta name="theme-color" content="#f6ebdc" />
+<!-- iOS status-bar / browser-chrome tint. Uses the --code-bg palette token
+     (#f2eee4 light / #1b2624 dark). Driven by JS below so it tracks the manual
+     theme toggle, not just the OS prefers-color-scheme. -->
+<meta name="theme-color" content="#f2eee4" />
 <script>
   // Set the theme before first paint to avoid a flash of the wrong theme,
   // and tint the status bar to match the chosen theme straight away.
@@ -21,7 +20,7 @@
     } catch (e) {}
     if (dark) {
       var m = document.querySelector('meta[name="theme-color"]');
-      if (m) m.content = "#4f524b";
+      if (m) m.content = "#1b2624";
     }
   })();
 </script>
@@ -96,7 +95,7 @@
       if (label) label.textContent = dark ? "Light" : "Dark";
       // Keep the status-bar tint matched to the active theme.
       var meta = document.querySelector('meta[name="theme-color"]');
-      if (meta) meta.content = dark ? "#4f524b" : "#f6ebdc";
+      if (meta) meta.content = dark ? "#1b2624" : "#f2eee4";
     }
     update();
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,10 +2,12 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<!-- iOS status-bar / browser-chrome tint. Uses the --code-bg palette token
-     (#f2eee4 light / #1b2624 dark). Driven by JS below so it tracks the manual
-     theme toggle, not just the OS prefers-color-scheme. -->
-<meta name="theme-color" content="#f2eee4" />
+<!-- iOS status-bar / browser-chrome tint. Mirrors the --theme-tint palette
+     token in css/main.css (#f6ebdc light / #4f524b dark) so the bar blends into
+     the hero rather than showing a band. Hardcoded here because the theme-color
+     meta can't read CSS vars before first paint; keep the two in sync. Driven by
+     JS below so it tracks the manual theme toggle, not just the OS. -->
+<meta name="theme-color" content="#f6ebdc" />
 <script>
   // Set the theme before first paint to avoid a flash of the wrong theme,
   // and tint the status bar to match the chosen theme straight away.
@@ -20,7 +22,7 @@
     } catch (e) {}
     if (dark) {
       var m = document.querySelector('meta[name="theme-color"]');
-      if (m) m.content = "#1b2624";
+      if (m) m.content = "#4f524b";
     }
   })();
 </script>
@@ -95,7 +97,7 @@
       if (label) label.textContent = dark ? "Light" : "Dark";
       // Keep the status-bar tint matched to the active theme.
       var meta = document.querySelector('meta[name="theme-color"]');
-      if (meta) meta.content = dark ? "#1b2624" : "#f2eee4";
+      if (meta) meta.content = dark ? "#4f524b" : "#f6ebdc";
     }
     update();
 

--- a/css/main.css
+++ b/css/main.css
@@ -7,6 +7,11 @@
   --apricot-cream: #efc495;
   --hairline: rgba(31, 42, 40, 0.12);
   --code-bg: #f2eee4;
+  /* iOS status-bar tint: the colour the page composites to at its very top,
+     where the fixed hero photo overlays the background. Kept in sync with the
+     hardcoded value in _layouts/default.html (theme-color meta can't read vars
+     before first paint). */
+  --theme-tint: #f6ebdc;
 
   --font-display: "halyard-display", "Helvetica Neue", Arial, sans-serif;
   --font-ui: "halyard-micro", "Helvetica Neue", Arial, sans-serif;
@@ -599,6 +604,7 @@ html.dark {
   --ink-soft: #9ba7a1;
   --hairline: rgba(233, 230, 221, 0.14);
   --code-bg: #1b2624;
+  --theme-tint: #4f524b;
 }
 
 /* Keep the apricot highlight legible (dark text on a light mark). */


### PR DESCRIPTION
The theme-color meta tags previously used flat porcelain and prefers-color-scheme
media queries. Two problems on iOS: (1) the very top of the page is the hero photo
overlay, not flat porcelain, so the status bar showed a pale band that scrolled with
the page; (2) the media-query tags follow the OS setting, so the manual light/dark
toggle could leave the bar mismatched.

Now a single theme-color meta is driven by JS to match the active theme, set to the
colour the page actually composites to at its top edge (#f6ebdc light, #4f524b dark),
updated on first paint, on toggle, and on OS preference change.